### PR TITLE
Add some options to optimize pretty-printing

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2763,9 +2763,12 @@ def serializeXML(element, options, ind = 0, preserveWhitespace = False):
 
    indent = ind
    I=''
-   if options.indent_type == 'tab': I='\t'
-   elif options.indent_type == 'space': I=' '
-   I *= options.indent_depth
+   newline = ''
+   if options.newlines:
+      if options.indent_type == 'tab': I='\t'
+      elif options.indent_type == 'space': I=' '
+      I *= options.indent_depth
+      newline = '\n'
 
    outParts.extend([(I * ind), '<', element.nodeName])
 
@@ -2824,7 +2827,7 @@ def serializeXML(element, options, ind = 0, preserveWhitespace = False):
             if preserveWhitespace:
                outParts.append(serializeXML(child, options, 0, preserveWhitespace))
             else:
-               outParts.extend(['\n', serializeXML(child, options, indent + 1, preserveWhitespace)])
+               outParts.extend([newline, serializeXML(child, options, indent + 1, preserveWhitespace)])
                onNewLine = True
          # text node
          elif child.nodeType == 3:
@@ -2846,10 +2849,10 @@ def serializeXML(element, options, ind = 0, preserveWhitespace = False):
 
       if onNewLine: outParts.append(I * ind)
       outParts.extend(['</', element.nodeName, '>'])
-      if indent > 0: outParts.append('\n')
+      if indent > 0: outParts.append(newline)
    else:
       outParts.append('/>')
-      if indent > 0: outParts.append('\n')
+      if indent > 0: outParts.append(newline)
 
    return "".join(outParts)
 
@@ -3168,6 +3171,9 @@ _options_parser.add_option("--indent",
 _options_parser.add_option("--nindent",
    action="store", type=int, dest="indent_depth", default=1,
    help="depth of the indentation, i.e. number of spaces/tabs: (default: %default)")
+_options_parser.add_option("--no-line-breaks",
+   action="store_false", dest="newlines", default=True,
+   help="do not create line breaks in output (also disables indentation; might be overriden by xml:space=\"preserve\")")
 _options_parser.add_option("--protect-ids-noninkscape",
    action="store_true", dest="protect_ids_noninkscape", default=False,
    help="Don't change IDs not ending with a digit")

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2922,6 +2922,9 @@ def scourString(in_string, options=None):
    if options.strip_comments:
       numCommentsRemoved = removeComments(doc)
 
+   if options.strip_xml_space_attribute and doc.documentElement.hasAttribute('xml:space'):
+      doc.documentElement.removeAttribute('xml:space')
+
    # repair style (remove unnecessary style properties and change them into XML attributes)
    numStylePropsFixed = repairStyle(doc.documentElement, options)
 
@@ -3174,6 +3177,9 @@ _options_parser.add_option("--nindent",
 _options_parser.add_option("--no-line-breaks",
    action="store_false", dest="newlines", default=True,
    help="do not create line breaks in output (also disables indentation; might be overriden by xml:space=\"preserve\")")
+_options_parser.add_option("--strip-xml-space",
+   action="store_true", dest="strip_xml_space_attribute", default=False,
+   help="strip the xml:space=\"preserve\" attribute from the root SVG element")
 _options_parser.add_option("--protect-ids-noninkscape",
    action="store_true", dest="protect_ids_noninkscape", default=False,
    help="Don't change IDs not ending with a digit")

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2765,6 +2765,7 @@ def serializeXML(element, options, ind = 0, preserveWhitespace = False):
    I=''
    if options.indent_type == 'tab': I='\t'
    elif options.indent_type == 'space': I=' '
+   I *= options.indent_depth
 
    outParts.extend([(I * ind), '<', element.nodeName])
 
@@ -3164,6 +3165,9 @@ _options_parser.add_option("-q", "--quiet",
 _options_parser.add_option("--indent",
    action="store", type="string", dest="indent_type", default="space",
    help="indentation of the output: none, space, tab (default: %default)")
+_options_parser.add_option("--nindent",
+   action="store", type=int, dest="indent_depth", default=1,
+   help="depth of the indentation, i.e. number of spaces/tabs: (default: %default)")
 _options_parser.add_option("--protect-ids-noninkscape",
    action="store_true", dest="protect_ids_noninkscape", default=False,
    help="Don't change IDs not ending with a digit")
@@ -3193,6 +3197,8 @@ def parse_args(args=None, ignore_additional_args=False):
       _options_parser.error("Can't have negative significant digits, see --help")
    if not options.indent_type in ["tab", "space", "none"]:
       _options_parser.error("Invalid value for --indent, see --help")
+   if options.indent_depth < 0:
+      _options_parser.error("Value for --nindent should be positive (or zero), see --help")
    if options.infilename and options.outfilename and options.infilename == options.outfilename:
       _options_parser.error("Input filename is the same as output filename")
 


### PR DESCRIPTION
This PR adds three new options:
* `--nindent` which allows to set the indentation depth (e.g. 2 spaces) therefore giving the user the possibility to adjust the pretty-printing to his personal preferences.
* `--no-line-breaks` which suppresses line breaks (and obviously also indentation) in the output altogether. This closes #10 and adds a possibility for a "minimal" output.
* `--strip-xml-space` tells Scour to remove the `xml:space` attribute from the root SVG element. At least one popular vector graphics editor adds `xml:space="preserve"` to the root SVG element thereby thwarting our efforts to pretty-print the output completely.

