### PR TITLE
Compatibility fix for Python 2.6

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2913,8 +2913,8 @@ def scourString(in_string, options=None):
          return False
       else:
          for element in doc.getElementsByTagName("*"):
-            for attrName in six.iterkeys(element.attributes):
-               if attrName.startswith(prefix):
+            for attribute in element.attributes.values():
+               if attribute.name.startswith(prefix):
                   return False
       return True
 


### PR DESCRIPTION
This is a small compatibility fix that should make the current version of Scour fully compatible with Python 2.6.5 again.