### PR TITLE
Hopefully definite fix for building from outside package directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,11 @@ Authors:
   - Tobias Oberstein (maintainer)
 """
 
-VERSIONFILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "scour", "__init__.py")
+old_path = os.getcwd()
+src_path = os.path.dirname(os.path.realpath(__file__))
+os.chdir(src_path)
+
+VERSIONFILE = "scour/__init__.py"
 verstrline = open(VERSIONFILE, "rt").read()
 VSRE = r"^__version__ = u['\"]([^'\"]*)['\"]"
 mo = re.search(VSRE, verstrline, re.M)
@@ -74,3 +78,5 @@ setup (
                   "Topic :: Utilities"],
    keywords = 'svg optimizer'
 )
+
+os.chdir(old_path)


### PR DESCRIPTION
(follow-up for 73ec7da13e668ae6555f20daa673c29659f390a4 and #41)

`find_packages` does not seem to work correctly when the working directory does not equal the package directory (resulted in the actual module not being installed).
Fix this by changing the working directory during setup.