### PR TITLE
Mechanism for sanitizing options

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -2866,8 +2866,9 @@ def serializeXML(element, options, ind = 0, preserveWhitespace = False):
 # input is a string representation of the input XML
 # returns a string representation of the output XML
 def scourString(in_string, options=None):
-   if options is None:
-      options = _options_parser.get_default_values()
+   # sanitize options (take missing attributes from defaults, discard unknown attributes)
+   options = sanitizeOptions(options)
+
    getcontext().prec = options.digits
    global numAttrsRemoved
    global numStylePropsFixed
@@ -3287,6 +3288,18 @@ def generateDefaultOptions():
    d = parse_args(args = [], ignore_additional_args = True)[0].__dict__.copy()
 
    return Struct(**d)
+
+
+
+# sanitizes options by updating attributes in a set of defaults options while discarding unknown attributes
+def sanitizeOptions(options):
+   optionsDict = dict((key, getattr(options, key)) for key in dir(options) if not key.startswith('__'))
+
+   sanitizedOptions = _options_parser.get_default_values()
+   sanitizedOptions._update_careful(optionsDict)
+
+   return sanitizedOptions
+
 
 
 def start(options, input, output):

--- a/testscour.py
+++ b/testscour.py
@@ -45,30 +45,31 @@ def walkTree(elem, func):
 		if walkTree(child, func) == False: return False
 	return True
 
+
 class ScourOptions:
-	simple_colors = True
-	style_to_xml = True
-	group_collapse = True
-	group_create = False
-	strip_ids = False
-	strip_comments = False
-	shorten_ids = False
-	shorten_ids_prefix = ""
-	embed_rasters = True
-	keep_defs = False
-	keep_editor_data = False
-	remove_metadata = False
-	renderer_workaround = True
-	strip_xml_prolog = False
-	enable_viewboxing = False
-	digits = 5
-	indent_type = "space"
-	indent_depth = 1
-	newlines = True
-	strip_xml_space_attribute = False
-	protect_ids_noninkscape = False
-	protect_ids_list = None
-	protect_ids_prefix = None
+	pass
+
+
+class EmptyOptions(unittest.TestCase):
+	def runTest(self):
+		options = ScourOptions
+		try:
+			scour.scourXmlFile('unittests/ids-to-strip.svg', options)
+			fail = False
+		except:
+			fail = True
+		self.assertEqual(fail, False, 'Exception when calling Scour with empty options object')
+
+class InvalidOptions(unittest.TestCase):
+	def runTest(self):
+		options = ScourOptions
+		options.invalidOption = "invalid value"
+		try:
+			scour.scourXmlFile('unittests/ids-to-strip.svg', options)
+			fail = False
+		except:
+			fail = True
+		self.assertEqual(fail, False, 'Exception when calling Scour with invalid options')
 
 class NoInkscapeElements(unittest.TestCase):
 	def runTest(self):


### PR DESCRIPTION
This PR adds an easy way to sanitize an `options` object that should be passed to `scourString`/`scourXmlFile`.
By generating a set of default options and "merging in" know attributes from the options passed to the function it is ensured that all attributes are correctly set (default values are used for unspecified attributes) while also removing unknown attributes.

Firstly this makes it easier to use Scour from another script (Instead of requiring explicit calling of `generateDefaultOptions` to get a copy of the latest options which have to be modified and fed back into Scour it's enough to generate an object that contains just the attributes that one wants to change).
Secondly it will avoid compatibility issues that may arise in case any options are added/removed/renamed in the future.