### PR TITLE
Switch order of new/old size in console output

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3312,11 +3312,11 @@ def start(options, input, output):
    sizediff = (newsize / oldsize) * 100.
 
    if not options.quiet:
-      print('Scour processed file "{}" in {} ms: {}/{} bytes orig/new -> {:.1f}%'.format(
+      print('Scour processed file "{}" in {} ms: {}/{} bytes new/orig -> {:.1f}%'.format(
          input.name,
          duration,
-         oldsize,
          newsize,
+         oldsize,
          sizediff))
       if options.verbose:
          print(getReport())


### PR DESCRIPTION
This is just a small cosmetic in the console output.

Since it already looks like a fraction, I guess we should order new/old size accordingly so it actually represents the displayed quotient of file sizes.