### PR TITLE
Add style argument which can convert SVG attributes to CSS Style attribute (the opposite of style_to_xml.)

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1819,7 +1819,7 @@ def repairStyle(node, options):
                 if propName in svgAttributes:
                     node.setAttribute(propName, styleMap[propName])
                     del styleMap[propName]
-      
+
         _setStyle(node, styleMap)
 
     # recurse for our child elements
@@ -3999,7 +3999,7 @@ _option_group_optimization.add_option("--disable-style-to-xml",
                                       help="won't convert styles into XML attributes")
 _option_group_optimization.add_option("--style",
                                       action="store", type="string", dest="style_type", default="none", metavar="TYPE",
-                                      help="style type (overrides style-to-xml): none, preserve, inline,"\
+                                      help="style type (overrides style-to-xml): none, preserve, inline,"
                                       "attributes (default: %none)")
 _option_group_optimization.add_option("--disable-group-collapsing",
                                       action="store_false", dest="group_collapse", default=True,

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1805,7 +1805,7 @@ def repairStyle(node, options):
         elif options.style_type == "preserve":
             # Keep whatever style of attribute versus style the file currently has
             pass
-        elif options.style_to_xml or options.style_type == "attributes":
+        elif options.style_type == "attributes":
             # now if any of the properties match known SVG attributes we prefer attributes
             # over style so emit them and remove them from the style map
             for propName in list(styleMap):
@@ -4083,6 +4083,10 @@ def parse_args(args=None, ignore_additional_args=False):
         _options_parser.error("Input filename is the same as output filename")
     if options.style_type not in ['none', 'preserve', 'attributes', 'inline-css']:
         _options_parser.error("Invalid value for --style, see --help")
+
+    #For backwards compatibility, we support style_to_xml but style_type can override it.
+    if options.style_type == 'none' and options.style_to_xml:
+      options.style_type = 'attributes'
 
     return options
 

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1804,11 +1804,12 @@ def repairStyle(node, options):
         if options.style_type == "inline":
             # Prefer inline style
             # Remove known SVG attributes and store their values in style attribute
-            attributes = [node.attributes.item(i).nodeName for i in range(node.attributes.length)]
+            attributes = [node.attributes.item(i) for i in range(node.attributes.length)]
             for attribute in attributes:
-                if attribute in svgAttributes:
-                    styleMap[attribute] = node.getAttribute(attribute)
-                    node.removeAttribute(attribute)
+                attributeName = attribute.nodeName
+                if attributeName in svgAttributes:
+                    styleMap[attributeName] = attribute.nodeValue
+                    node.removeAttribute(attributeName)
         elif options.style_type == "preserve":
             # Keep whatever style of attribute versus style the file currently has
             pass

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1801,26 +1801,26 @@ def repairStyle(node, options):
                 num += 1
 
     if node.nodeType == Node.ELEMENT_NODE:
-      if options.style_type == "inline":
-        # Prefer inline style
-        # Remove known SVG attributes and store their values in style attribute
-        attributes = [node.attributes.item(i).nodeName for i in range(node.attributes.length)]
-        for attribute in attributes:
-          if attribute in svgAttributes:
-            styleMap[attribute] = node.getAttribute(attribute)
-            node.removeAttribute(attribute)
-      elif options.style_type == "preserve":
-        # Keep whatever style of attribute versus style the file currently has
-        pass
-      elif options.style_to_xml or options.style_type == "attributes":
-        # now if any of the properties match known SVG attributes we prefer attributes
-        # over style so emit them and remove them from the style map
-        for propName in list(styleMap):
-            if propName in svgAttributes:
-                node.setAttribute(propName, styleMap[propName])
-                del styleMap[propName]
+        if options.style_type == "inline":
+            # Prefer inline style
+            # Remove known SVG attributes and store their values in style attribute
+            attributes = [node.attributes.item(i).nodeName for i in range(node.attributes.length)]
+            for attribute in attributes:
+                if attribute in svgAttributes:
+                    styleMap[attribute] = node.getAttribute(attribute)
+                    node.removeAttribute(attribute)
+        elif options.style_type == "preserve":
+            # Keep whatever style of attribute versus style the file currently has
+            pass
+        elif options.style_to_xml or options.style_type == "attributes":
+            # now if any of the properties match known SVG attributes we prefer attributes
+            # over style so emit them and remove them from the style map
+            for propName in list(styleMap):
+                if propName in svgAttributes:
+                    node.setAttribute(propName, styleMap[propName])
+                    del styleMap[propName]
       
-      _setStyle(node, styleMap)
+        _setStyle(node, styleMap)
 
     # recurse for our child elements
     for child in node.childNodes:
@@ -3999,7 +3999,8 @@ _option_group_optimization.add_option("--disable-style-to-xml",
                                       help="won't convert styles into XML attributes")
 _option_group_optimization.add_option("--style",
                                       action="store", type="string", dest="style_type", default="none", metavar="TYPE",
-                                      help="styles type (override style_to_xml): none, preserve, inline, attributes (default: %none)")
+                                      help="style type (overrides style-to-xml): none, preserve, inline,"\
+                                      "attributes (default: %none)")
 _option_group_optimization.add_option("--disable-group-collapsing",
                                       action="store_false", dest="group_collapse", default=True,
                                       help="won't collapse <g> elements")

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -61,7 +61,7 @@ from collections import namedtuple, defaultdict
 from decimal import Context, Decimal, InvalidOperation, getcontext
 
 import six
-from six.moves import range, urllib
+import urllib
 
 from scour.stats import ScourStats
 from scour.svg_regex import svg_parser
@@ -3963,8 +3963,8 @@ _option_group_optimization.add_option("--disable-style-to-xml",
                                       help="won't convert styles into XML attributes")
 _option_group_optimization.add_option("--style",
                                       action="store", type="string", dest="style_type", default="none", metavar="TYPE",
-                                      help="style type (overrides style-to-xml): none, preserve, inline-css,"
-                                      "attributes (default: %none)")
+                                      help="style type (overrides style-to-xml): none, preserve, inline-css, "
+                                      "attributes (default: none)")
 _option_group_optimization.add_option("--disable-group-collapsing",
                                       action="store_false", dest="group_collapse", default=True,
                                       help="won't collapse <g> elements")
@@ -4208,4 +4208,5 @@ def run():
 
 
 if __name__ == '__main__':
+    print('running')
     run()

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -4084,10 +4084,6 @@ def parse_args(args=None, ignore_additional_args=False):
     if options.style_type not in ['none', 'preserve', 'attributes', 'inline-css']:
         _options_parser.error("Invalid value for --style, see --help")
 
-    #For backwards compatibility, we support style_to_xml but style_type can override it.
-    if options.style_type == 'none' and options.style_to_xml:
-      options.style_type = 'attributes'
-
     return options
 
 
@@ -4103,6 +4099,10 @@ def sanitizeOptions(options=None):
 
     sanitizedOptions = _options_parser.get_default_values()
     sanitizedOptions._update_careful(optionsDict)
+
+    #For backwards compatibility, we support style_to_xml but style_type can override it.
+    if sanitizedOptions.style_type == 'none' and sanitizedOptions.style_to_xml:
+      sanitizedOptions.style_type = 'attributes'
 
     return sanitizedOptions
 

--- a/scour/scour.py
+++ b/scour/scour.py
@@ -1793,7 +1793,7 @@ def repairStyle(node, options):
                 num += 1
 
     if node.nodeType == Node.ELEMENT_NODE:
-        if options.style_type == "inline":
+        if options.style_type == "inline-css":
             # Prefer inline style
             # Remove known SVG attributes and store their values in style attribute
             attributes = [node.attributes.item(i) for i in range(node.attributes.length)]
@@ -3963,7 +3963,7 @@ _option_group_optimization.add_option("--disable-style-to-xml",
                                       help="won't convert styles into XML attributes")
 _option_group_optimization.add_option("--style",
                                       action="store", type="string", dest="style_type", default="none", metavar="TYPE",
-                                      help="style type (overrides style-to-xml): none, preserve, inline,"
+                                      help="style type (overrides style-to-xml): none, preserve, inline-css,"
                                       "attributes (default: %none)")
 _option_group_optimization.add_option("--disable-group-collapsing",
                                       action="store_false", dest="group_collapse", default=True,
@@ -4081,7 +4081,7 @@ def parse_args(args=None, ignore_additional_args=False):
         _options_parser.error("Value for --nindent should be positive (or zero), see --help")
     if options.infilename and options.outfilename and options.infilename == options.outfilename:
         _options_parser.error("Input filename is the same as output filename")
-    if options.style_type not in ['none', 'preserve', 'attributes', 'inline']:
+    if options.style_type not in ['none', 'preserve', 'attributes', 'inline-css']:
         _options_parser.error("Invalid value for --style, see --help")
 
     return options

--- a/test_scour.py
+++ b/test_scour.py
@@ -2217,7 +2217,7 @@ class AttrToStyle(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/attr-to-style.svg',
-            parse_args(['--style=inline']))
+                           parse_args(['--style=inline']))
         line = doc.getElementsByTagName('line')[0]
         self.assertEqual(line.getAttribute('stroke'), '')
         self.assertEqual(line.getAttribute('marker-start'), '')
@@ -2237,7 +2237,7 @@ class StylePreserve(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/attr-to-style.svg',
-            parse_args(['--style=preserve']))
+                           parse_args(['--style=preserve']))
 
         # First line uses attributes.
         line = doc.getElementsByTagName('line')[0]

--- a/test_scour.py
+++ b/test_scour.py
@@ -2212,11 +2212,12 @@ class StyleToAttr(unittest.TestCase):
         self.assertEqual(line.getAttribute('marker-mid'), 'url(#m)')
         self.assertEqual(line.getAttribute('marker-end'), 'url(#m)')
 
+
 class AttrToStyle(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/attr-to-style.svg',
-          parse_args(['--style=inline']))
+            parse_args(['--style=inline']))
         line = doc.getElementsByTagName('line')[0]
         self.assertEqual(line.getAttribute('stroke'), '')
         self.assertEqual(line.getAttribute('marker-start'), '')
@@ -2231,25 +2232,27 @@ class AttrToStyle(unittest.TestCase):
         self.assertTrue("marker-end:url(#m)" in rawStyles)
         self.assertTrue("marker-mid:url(#m)" in rawStyles)
 
+
 class StylePreserve(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/attr-to-style.svg',
-          parse_args(['--style=preserve']))
+            parse_args(['--style=preserve']))
 
-        #First line uses attributes.
+        # First line uses attributes.
         line = doc.getElementsByTagName('line')[0]
         self.assertNotEqual(line.getAttribute('stroke'), '')
         self.assertNotEqual(line.getAttribute('marker-start'), '')
         self.assertNotEqual(line.getAttribute('marker-mid'), '')
         self.assertNotEqual(line.getAttribute('marker-end'), '')
 
-        #Second line uses style attribute.
+        # Second line uses style attribute.
         line = doc.getElementsByTagName('line')[1]
         self.assertEqual(line.getAttribute('stroke'), '')
         self.assertEqual(line.getAttribute('marker-start'), '')
         self.assertEqual(line.getAttribute('marker-mid'), '')
         self.assertEqual(line.getAttribute('marker-end'), '')
+
 
 class PathCommandRewrites(unittest.TestCase):
 

--- a/test_scour.py
+++ b/test_scour.py
@@ -2212,6 +2212,44 @@ class StyleToAttr(unittest.TestCase):
         self.assertEqual(line.getAttribute('marker-mid'), 'url(#m)')
         self.assertEqual(line.getAttribute('marker-end'), 'url(#m)')
 
+class AttrToStyle(unittest.TestCase):
+
+    def runTest(self):
+        doc = scourXmlFile('unittests/attr-to-style.svg',
+          parse_args(['--style=inline']))
+        line = doc.getElementsByTagName('line')[0]
+        self.assertEqual(line.getAttribute('stroke'), '')
+        self.assertEqual(line.getAttribute('marker-start'), '')
+        self.assertEqual(line.getAttribute('marker-mid'), '')
+        self.assertEqual(line.getAttribute('marker-end'), '')
+
+        style_attribute = line.getAttribute('style')
+        rawStyles = style_attribute.split(';')
+        self.assertTrue("color:#FF0000" in rawStyles)
+        self.assertTrue("stroke:#000" in rawStyles)
+        self.assertTrue("marker-start:url(#m)" in rawStyles)
+        self.assertTrue("marker-end:url(#m)" in rawStyles)
+        self.assertTrue("marker-mid:url(#m)" in rawStyles)
+
+class StylePreserve(unittest.TestCase):
+
+    def runTest(self):
+        doc = scourXmlFile('unittests/attr-to-style.svg',
+          parse_args(['--style=preserve']))
+
+        #First line uses attributes.
+        line = doc.getElementsByTagName('line')[0]
+        self.assertNotEqual(line.getAttribute('stroke'), '')
+        self.assertNotEqual(line.getAttribute('marker-start'), '')
+        self.assertNotEqual(line.getAttribute('marker-mid'), '')
+        self.assertNotEqual(line.getAttribute('marker-end'), '')
+
+        #Second line uses style attribute.
+        line = doc.getElementsByTagName('line')[1]
+        self.assertEqual(line.getAttribute('stroke'), '')
+        self.assertEqual(line.getAttribute('marker-start'), '')
+        self.assertEqual(line.getAttribute('marker-mid'), '')
+        self.assertEqual(line.getAttribute('marker-end'), '')
 
 class PathCommandRewrites(unittest.TestCase):
 

--- a/test_scour.py
+++ b/test_scour.py
@@ -2217,7 +2217,7 @@ class AttrToStyle(unittest.TestCase):
 
     def runTest(self):
         doc = scourXmlFile('unittests/attr-to-style.svg',
-                           parse_args(['--style=inline']))
+                           parse_args(['--style=inline-css']))
         line = doc.getElementsByTagName('line')[0]
         self.assertEqual(line.getAttribute('stroke'), '')
         self.assertEqual(line.getAttribute('marker-start'), '')

--- a/unittests/attr-to-style.svg
+++ b/unittests/attr-to-style.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <marker id="m">
+    <rect width="200" height="100"/>
+  </marker>
+</defs>
+<line x2="100" stroke="#000" marker-start="url(#m)" marker-end="url(#m)" marker-mid="url(#m)" style="color:#FF0000" />
+<line x2="100" style="stroke:#000; marker-start:url(#m); marker-end:url(#m); marker-mid: url(#m)" />
+</svg>


### PR DESCRIPTION
Currently, scour allows the user two options when it comes to SVG Attributes versus CSS Style: They can either convert everything to SVG Attributes or leave all the attributes as they were originally encoded. Obviously, there is a third option, which is currently missing: convert everything to CSS Style.

While SVG Attributes are generally preferred for various CSS overriding reasons, some tools don't handle them well and prefer CSS Style. For example, Inkscape's "Save As HTML 5 Canvas" doesn't support SVG Attributes but does support CSS Style.  For this reason, tools like Illustrator allow the user to choose between "Inline" or "Presentational Attributes" (or a third option, "Internal CSS" which is out of scope for this discussion.) The eventual goal of this change would be to add an option to Inkscape so it behaves somewhat like Illustrator with three options: "Preserve", "Presentational Attributes", "Inline".

This pull request adds the option to convert styling all to CSS Style through --style=inline. The other options are --style=none, --style=attributes, --style=preserve. 

The backwards compatibility logic is slightly annoying. If you specify a --style other than "none", then that style will be used. If you specify --style=none (or specify nothing, as none is the default) then --disable-style-to-xml or --style-to-xml will decide the behavior. Perhaps "none" could renamed "default?"