### PR TITLE
Check xlink:href for gradientUnits="userSpaceOnUse"

### DIFF
--- a/test_scour.py
+++ b/test_scour.py
@@ -1517,8 +1517,21 @@ class RemoveRedundantSvgNamespacePrefix(unittest.TestCase):
 class RemoveDefaultGradX1Value(unittest.TestCase):
 
     def runTest(self):
-        g = scourXmlFile('unittests/gradient-default-attrs.svg').getElementById('grad1')
-        self.assertEqual(g.getAttribute('x1'), '',
+        doc = scourXmlFile('unittests/gradient-default-attrs.svg')
+        g1 = doc.getElementById('grad1')
+        g1b = doc.getElementById('grad1b')
+        g1c = doc.getElementById('grad1c')
+        g1d = doc.getElementById('grad1d')
+        g1e = doc.getElementById('grad1e')
+        self.assertEqual(g1.getAttribute('x1'), '',
+                         'x1="0" not removed')
+        self.assertEqual(g1b.getAttribute('x1'), '',
+                         'x1="0" not removed')
+        self.assertEqual(g1c.getAttribute('x1'), '',
+                         'x1="0" removed (but should not be due to gradientUnits)')
+        self.assertEqual(g1d.getAttribute('x1'), '',
+                         'x1="0" removed (but should not be due to href)')
+        self.assertEqual(g1e.getAttribute('x1'), '',
                          'x1="0" not removed')
 
 

--- a/unittests/gradient-default-attrs.svg
+++ b/unittests/gradient-default-attrs.svg
@@ -12,10 +12,20 @@
     <stop offset="0" stop-color="black"/>
     <stop offset="1" stop-color="white"/>
   </linearGradient>
+  <linearGradient id="grad1d" x2='1' xlink:href="#grad1c">
+    <stop offset="0" stop-color="black"/>
+    <stop offset="1" stop-color="white"/>
+  </linearGradient>
+  <linearGradient id="grad1e" x2='1' xlink:href="#grad1b">
+    <stop offset="0" stop-color="black"/>
+    <stop offset="1" stop-color="white"/>
+  </linearGradient>
   <radialGradient id="grad2" xlink:href="#grad1" cx="50%" cy="0.5" r="50%" fx="50%" fy="0.5"/>
   
   <rect width="100" height="100" fill="url(#grad1)"/>
   <rect width="100" height="100" fill="url(#grad1b)"/>
   <rect width="100" height="100" fill="url(#grad1c)"/>
+  <rect width="100" height="100" fill="url(#grad1d)"/>
+  <rect width="100" height="100" fill="url(#grad1e)"/>
   <rect width="50" height="50" fill="url(#grad2)"/>
 </svg>


### PR DESCRIPTION
When considering to prune attributes set to a default values, we
checked the `gradientUnits` attribute first to determine if that was
valid. Unfortunately, we omitted to check whether the `gradientUnits`
attribute was inherited via `xlink:ref`.  This commit corrects that
bug.

Closes: #225
Signed-off-by: Niels Thykier <niels@thykier.net>