### PR TITLE
Fix trivial typos

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -340,7 +340,7 @@ colors = {
     'yellowgreen': 'rgb(154, 205, 50)',
 }
 
-# A list of default poperties that are safe to remove
+# A list of default properties that are safe to remove
 #
 # Sources for this list:
 #     https://www.w3.org/TR/SVG/propidx.html              (implemented)

--- a/test_scour.py
+++ b/test_scour.py
@@ -1123,7 +1123,7 @@ class BooleanFlagsInEllipticalPath(unittest.TestCase):
         paths = doc.getElementsByTagNameNS(SVGNS, 'path')
         for path in paths:
             self.assertEqual(path.getAttribute('d'), 'm0 0a100 50 0 00100 50',
-                             'Did not ommit spaces after boolean flags in elliptical arg path command')
+                             'Did not omit spaces after boolean flags in elliptical arg path command')
 
     def test_output_spaces_with_renderer_workaround(self):
         doc = scourXmlFile('unittests/path-elliptical-flags.svg', parse_args(['--renderer-workaround']))


### PR DESCRIPTION
Found via `codespell -q 3 -L ba`