### PR TITLE
Fix #296, don't remove elements with referenced children

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -646,7 +646,7 @@ def removeUnusedDefs(doc, defElem, elemsToRemove=None, referencedIDs=None):
     # removeUnusedDefs do not change the XML itself; therefore there is no point in
     # recomputing findReferencedElements when we recurse into child nodes.
     if referencedIDs is None:
-        referencedIDs = findReferencedElements(doc.documentElement)
+        referencedIDs = set(findReferencedElements(doc.documentElement).keys())
 
     keepTags = ['font', 'style', 'metadata', 'script', 'title', 'desc']
     for elem in defElem.childNodes:
@@ -660,10 +660,13 @@ def removeUnusedDefs(doc, defElem, elemsToRemove=None, referencedIDs=None):
             # we only inspect the children of a group in a defs if the group
             # is not referenced anywhere else
             if elem.nodeName == 'g' and elem.namespaceURI == NS['SVG']:
-                elemsToRemove = removeUnusedDefs(doc, elem, elemsToRemove, referencedIDs=referencedIDs)
+                removeUnusedDefs(doc, elem, elemsToRemove, referencedIDs=referencedIDs)
             # we only remove if it is not one of our tags we always keep (see above)
+            # also we can't remove an element if a child is referenced
             elif elem.nodeName not in keepTags:
-                elemsToRemove.append(elem)
+                if (set(findElementsWithId(elem).keys()).intersection(referencedIDs) == set() or
+                        elem.tagName == 'defs'):
+                    elemsToRemove.append(elem)
     return elemsToRemove
 
 

--- a/test_scour.py
+++ b/test_scour.py
@@ -379,6 +379,13 @@ class KeepUnreferencedDefs(unittest.TestCase):
         self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'circle')), 1,
                          'Unreferenced circle removed from defs with `--keep-unreferenced-defs`')
 
+class KeepUnreferencedElementWithReferencedChild(unittest.TestCase):
+    def runTest(self):
+        doc = scourXmlFile('unittests/referenced_child.svg')
+
+        self.assertEqual(len(doc.getElementsByTagNameNS(SVGNS, 'rect')), 1,
+                         'Referenced element was deleted')
+
 
 class DoNotRemoveChainedRefsInDefs(unittest.TestCase):
 

--- a/unittests/referenced_child.svg
+++ b/unittests/referenced_child.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <clipPath id="unusedclip">
+  <rect id="the_path" width="100" height="100"/>
+  </clipPath>
+ </defs>
+ <use fill="red" width="100%" height="100%" xlink:href="#the_path"/>
+</svg>


### PR DESCRIPTION
Before adding an element to the list of to-be-removed-elements, we need to check if a child of this element is in the list of referenced IDs.

Closes #296

Added a unit test; the existing unit tests are working. Also flake-8 doesn't complain about the newly-added code.