### PR TITLE
fix missing whitespace, line 3632 flake8

### DIFF
--- a/scour/scour.py
+++ b/scour/scour.py
@@ -3629,7 +3629,7 @@ def scourString(in_string, options=None, stats=None):
         stats = ScourStats()
 
     # default or invalid value
-    if(options.cdigits < 0):
+    if (options.cdigits < 0):
         options.cdigits = options.digits
 
     # create decimal contexts with reduced precision for scouring numbers


### PR DESCRIPTION
Hello,
A minor error.
$ make check 
revealed flake8 error in master
.\scour\scour.py:3632:7: E275 missing whitespace after keyword

Please confirm this PR. Next PR is sphinx documentation.
Thank you